### PR TITLE
Tell Pyre to check tensorflow_program_bugs

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,6 +1,7 @@
 {
   "source_directories": [
-    "time_sequence_prediction"
+    "time_sequence_prediction",
+    "tensorflow_program_bugs"
   ],
   "search_path": ["stubs"],
   "taint_models_path": "/Users/pradeepkumars/.pyenv/versions/3.6.6/lib"


### PR DESCRIPTION
This is gonna make Pyre super unhappy because we don't have stubs for the examples in tensorflow_program_bugs yet. Should we add dummy stubs for everything required now, or add them incrementally as we go?