### PR TITLE
2. Simplify and fix UT2

### DIFF
--- a/stubs/tensorflow/__init__.pyi
+++ b/stubs/tensorflow/__init__.pyi
@@ -14,6 +14,7 @@ from typing import (
     Tuple,
     TypeVar,
     Type,
+    Union,
 )
 
 from pyre_extensions import TypeVarTuple, Unpack
@@ -27,6 +28,12 @@ A2 = TypeVar("A2")
 A3 = TypeVar("A3")
 A4 = TypeVar("A4")
 A5 = TypeVar("A5")
+
+ArrayLike = Union[
+    ndarray[Unpack[Ts]],
+    Tensor[Any, Unpack[Ts]],
+    Variable[Unpack[Ts]],
+]
 
 class Variable(Generic[Unpack[Ts]]):
     shape: Tuple[Unpack[Ts]]
@@ -56,9 +63,13 @@ class Tensor(Generic[T, Unpack[Ts]]):
     shape: Tuple[Unpack[Ts]]
     def __eq__(self, other: Tensor[T, Unpack[Ts]]) -> bool: ...
 
+# ===== Begin matmul =====
+
+# Normal matrix multiplication: (A1, A2) x (A2, A3).
+@overload
 def matmul(
-    a,
-    b,
+    a: ArrayLike[A1, A2],
+    b: ArrayLike[A2, A3],
     transpose_a=...,
     transpose_b=...,
     adjoint_a=...,
@@ -66,7 +77,38 @@ def matmul(
     a_is_sparse=...,
     b_is_sparse=...,
     name=...,
-) -> Any: ...
+) -> Tensor[A1, A3]: ...
+
+# (A2, A3) x (A3, A4) with a batch size of A1.
+@overload
+def matmul(
+    a: ArrayLike[A1, A2, A3],
+    b: ArrayLike[A1, A3, A4],
+    transpose_a=...,
+    transpose_b=...,
+    adjoint_a=...,
+    adjoint_b=...,
+    a_is_sparse=...,
+    b_is_sparse=...,
+    name=...,
+) -> Tensor[A1, A2, A4]: ...
+
+# (A1, A2) x (A2, A3), with a batch size of A4,
+# with first arg converted to batch size A4 through broadcasting.
+@overload
+def matmul(
+    a: ArrayLike[A1, A2],
+    b: ArrayLike[A4, A2, A3],
+    transpose_a=...,
+    transpose_b=...,
+    adjoint_a=...,
+    adjoint_b=...,
+    a_is_sparse=...,
+    b_is_sparse=...,
+    name=...,
+) -> Tensor[A4, A1, A3]: ...
+
+# ===== End matmul =====
 @overload
 def zeros(
     shape: Tuple[Unpack[Ts]], dtype: Type[T], name: str = ...

--- a/tensorflow_program_bugs/ut_2_multiplication.py
+++ b/tensorflow_program_bugs/ut_2_multiplication.py
@@ -1,29 +1,21 @@
-# UT-2 from
+# UT-2 adapted from
 # https://github.com/ForeverZyh/TensorFlow-Program-Bugs/blob/master/StackOverflow/UT-2/43067338-buggy/multiplication.py
+# in turn from
+# https://stackoverflow.com/questions/43067338/tensor-multiplication-in-tensorflow
 
-# Verdict: This needs broadcasting from type arithmetic.
+from typing_extensions import Literal
 
 import numpy as np
 import tensorflow as tf
 
-M = 5
-N = 2
-T = 3
-h = 2
-s = 3
-A_np = np.random.randn(M, h)
-C_np = np.random.randn(s, T)
-B_np = np.random.randn(h, N, s)
+L2 = Literal[2]
+L3 = Literal[3]
+L5 = Literal[5]
 
-A_tf = tf.Variable(A_np)
-C_tf = tf.Variable(C_np)
-B_tf = tf.Variable(B_np)
+matrix1 = tf.Variable(np.random.randn(5, 2))
+matrix2 = tf.Variable(np.random.randn(2, 2, 3))
 
-# Tensorflow
-with tf.Session() as sess:
-    sess.run(tf.global_variables_initializer())
-    print(sess.run(A_tf))
-    # 5x2 times 2x2x3 needs to be 2x5x3 because of broadcasting. We don't
-    # currently support broadcasting.
-    p = tf.matmul(A_tf, B_tf)
-    print(sess.run(p))
+# This is what you'd _think_ the shape would be:
+# result: tf.Tensor[L5, L2, L3] = tf.matmul(matrix1, matrix2)
+# But `matmul` is weird, and the result is _actually_:
+result: tf.Tensor[L2, L5, L3] = tf.matmul(matrix1, matrix2)


### PR DESCRIPTION
I was making a slide for this example, and a) wanted to make it a bit more concise, and b) realised I was really confused about it.

I was confused because this code doesn't actually produce an error - the `matmul` is valid. Checking the source, https://stackoverflow.com/questions/43067338/tensor-multiplication-in-tensorflow, it looks like at _some_ point it didn't _used_ to be valid, but now the semantics of `matmul` have changed so that it _is_ valid.

I think the real story here is "Wow, `matmul` does _not_ behave as you'd expect it to". So I've tried modifying the code to reflect that.